### PR TITLE
Added response to 'All Notes Off' MIDI message - Resolves #11

### DIFF
--- a/EP-MK1-Plugins/EP-MK1-Linux64/EP-MK1/EP-MK1.pd
+++ b/EP-MK1-Plugins/EP-MK1-Linux64/EP-MK1/EP-MK1.pd
@@ -1,4 +1,4 @@
-#N canvas 739 334 1034 686 10;
+#N canvas 639 195 1063 729 10;
 #X obj 21 649 dac~ 1 2;
 #N canvas 4 23 162 227 hv.tanh 0;
 #X obj 12 12 inlet~;
@@ -28,7 +28,7 @@
 #X obj 89 567 -~;
 #X obj 139 483 +~ 0.5;
 #X obj 21 581 *~;
-#N canvas 1377 381 455 411 parameters 0;
+#N canvas 1377 381 455 411 parameters 1;
 #X obj 122 293 + 100;
 #X obj 122 314 dbtorms;
 #X msg 122 335 \$1 20;
@@ -448,7 +448,7 @@
 #X obj 72 116 + 1;
 #X obj 323 140 list prepend read;
 #X obj 153 51 t f b, f 11;
-#X floatatom 227 89 5 0 0 0 - - -;
+#X floatatom 227 89 5 0 0 0 - - -, f 5;
 #X msg 227 130 clear;
 #X msg 272 96 set 1;
 #X obj 227 108 sel 0;
@@ -497,9 +497,9 @@
 #X obj 666 286 notein;
 #X obj 806 300 > 0;
 #X obj 806 321 sel 1;
-#X msg 586 293 stop;
+#X msg 584 293 stop;
 #X obj 806 342 s \$0-rcv-mid;
-#X obj 586 272 r \$0-snd-stp;
+#X obj 584 270 r \$0-snd-stp;
 #X obj 818 427 text get \$0-tuning;
 #X obj 688 406 pow;
 #X obj 720 413 r \$0-bas-frq;
@@ -35718,66 +35718,66 @@
 #X connect 127 1 125 1;
 #X connect 128 0 127 0;
 #X restore 21 534 pd voices;
-#X obj 10 35 cnv 24 566 300 empty empty empty 20 12 0 14 -162280 -66577
+#X obj 10 35 cnv 24 566 300 empty empty empty 20 12 0 14 #9c9c9c #404040
 0;
-#X obj 15 148 cnv 17 144 182 empty empty empty 20 12 0 14 -228856 -66577
+#X obj 15 148 cnv 17 144 182 empty empty empty 20 12 0 14 #dcdcdc #404040
 0;
-#X obj 165 148 cnv 17 160 182 empty empty empty 20 12 0 14 -228856
--66577 0;
-#X obj 331 148 cnv 17 144 182 empty empty empty 20 12 0 14 -228856
--66577 0;
-#X obj 481 148 cnv 17 90 182 empty empty empty 20 12 0 14 -228856 -66577
+#X obj 165 148 cnv 17 160 182 empty empty empty 20 12 0 14 #dcdcdc
+#404040 0;
+#X obj 331 148 cnv 17 144 182 empty empty empty 20 12 0 14 #dcdcdc
+#404040 0;
+#X obj 481 148 cnv 17 90 182 empty empty empty 20 12 0 14 #dcdcdc #404040
 0;
 #X obj 170 228 nbx 4 17 1 2000 0 0 \$0-ton-rel \$0-rcv-ton-rel empty
-0 -8 0 10 -1 -262144 -1 1 256;
+0 -8 0 10 #000000 #fcfcfc #000000 1 256 0;
 #X text 168 212 RELEASE;
 #X obj 170 188 nbx 4 17 1 2000 0 0 \$0-ton-dec \$0-rcv-ton-dec empty
-0 -8 0 10 -1 -262144 -1 1 256;
+0 -8 0 10 #000000 #fcfcfc #000000 1 256 0;
 #X text 168 172 DECAY;
 #X obj 170 268 nbx 4 17 -100 0 0 0 \$0-snd-ton-lvl \$0-rcv-ton-lvl
-empty 0 -8 0 10 -1 -262144 -1 0 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 168 252 LEVEL;
-#X obj 240 188 tgl 17 0 \$0-snd-pdl \$0-rcv-pdl empty 17 7 0 10 -1
--262144 -1 0 1;
+#X obj 240 188 tgl 17 0 \$0-snd-pdl \$0-rcv-pdl empty 17 7 0 10 #000000
+#fcfcfc #000000 0 1;
 #X text 238 172 SUS. PEDAL;
 #X obj 336 228 nbx 5 17 20 20000 0 0 \$0-pic-lop \$0-rcv-pic-lop empty
-0 -8 0 10 -1 -262144 -1 20 256;
+0 -8 0 10 #000000 #fcfcfc #000000 20 256 0;
 #X obj 336 188 nbx 4 17 0 30 0 0 \$0-snd-pic-gan \$0-rcv-pic-gan empty
-0 -8 0 10 -1 -262144 -1 0 256;
+0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 384 189 dB;
 #X text 394 229 Hz;
 #X obj 336 268 nbx 4 17 0 30 0 0 \$0-snd-pic-sym \$0-rcv-pic-sym empty
-0 -8 0 10 -1 -262144 -1 0 256;
+0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 334 252 SYMMETRY;
 #X text 384 269 dB;
 #X obj 336 308 nbx 4 17 -100 6 0 0 \$0-snd-pic-lvl \$0-rcv-pic-lvl
-empty 0 -8 0 10 -1 -262144 -1 0 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 334 292 LEVEL;
 #X obj 240 268 nbx 4 17 -100 0 0 0 \$0-snd-ham-lvl \$0-rcv-ham-lvl
-empty 0 -8 0 10 -1 -262144 -1 0 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 288 269 dB;
 #X text 218 269 dB;
 #X text 238 252 HAMMER LEVEL;
 #X obj 240 228 nbx 4 17 -100 0 0 0 \$0-snd-off-lvl \$0-rcv-off-lvl
-empty 0 -8 0 10 -1 -262144 -1 0 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 288 229 dB;
 #X text 238 212 NOTEOFF LEVEL;
 #X obj 20 228 nbx 5 17 20 20000 0 0 \$0-tin-hip \$0-rcv-tin-hip empty
-0 -8 0 10 -1 -262144 -1 20 256;
+0 -8 0 10 #000000 #fcfcfc #000000 20 256 0;
 #X text 78 229 Hz;
 #X obj 20 188 nbx 4 17 0 30 0 0 \$0-tin-rat-1 \$0-rcv-tin-rat-1 empty
-0 -8 0 10 -1 -262144 -1 0 256;
+0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X obj 80 188 nbx 4 17 0 30 0 0 \$0-tin-rat-2 \$0-rcv-tin-rat-2 empty
-0 -8 0 10 -1 -262144 -1 0 256;
+0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X obj 20 268 nbx 4 17 1 2000 0 0 \$0-tin-dec \$0-rcv-tin-dec empty
-0 -8 0 10 -1 -262144 -1 1 256;
+0 -8 0 10 #000000 #fcfcfc #000000 1 256 0;
 #X text 384 309 dB;
 #X obj 20 308 nbx 4 17 -100 0 0 0 \$0-snd-tin-lvl \$0-rcv-tin-lvl empty
-0 -8 0 10 -1 -262144 -1 0 256;
+0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 18 292 LEVEL;
 #X text 68 309 dB;
 #X obj 406 188 nbx 4 17 -100 30 0 0 \$0-snd-pic-atk \$0-rcv-pic-atk
-empty 0 -8 0 10 -1 -262144 -1 0 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 454 189 dB;
 #X text 404 172 ATTACK;
 #X text 334 172 GAIN;
@@ -35785,88 +35785,88 @@ empty 0 -8 0 10 -1 -262144 -1 0 256;
 #X text 18 172 RATIO 1;
 #X text 78 172 RATIO 2;
 #X obj 406 308 nbx 4 17 -100 0 0 0 \$0-snd-pic-buz \$0-rcv-pic-buz
-empty 0 -8 0 10 -1 -262144 -1 0 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 454 309 dB;
 #X text 404 292 BUZZ LEVEL;
 #X obj 406 268 tgl 17 0 \$0-snd-buz-pha \$0-rcv-buz-pha empty 17 7
-0 10 -1 -262144 -1 0 1;
+0 10 #000000 #fcfcfc #000000 0 1;
 #X text 404 252 BUZZ PHASE;
 #X obj 90 308 nbx 4 17 -100 24 0 0 \$0-snd-tin-snd \$0-rcv-tin-snd
-empty 0 -8 0 10 -1 -262144 -1 0 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 138 309 dB;
 #X text 88 292 PICK SEND;
 #X obj 486 268 nbx 5 17 0 20000 0 0 \$0-tre-rat \$0-rcv-tre-rat empty
-0 -8 0 10 -1 -262144 -1 0 256;
+0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 544 269 Hz;
 #X text 484 252 RATE;
 #X obj 486 228 nbx 4 17 0 127 0 0 \$0-tre-sha \$0-rcv-tre-sha empty
-0 -8 0 10 -1 -262144 -1 0 256;
+0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 484 212 SHAPE SIN/TRI;
 #X obj 486 308 nbx 4 17 -100 0 0 0 \$0-snd-tre-dep \$0-rcv-tre-dep
-empty 0 -8 0 10 -1 -262144 -1 0 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 534 309 dB;
 #X obj 486 188 tgl 17 0 \$0-snd-tre-tgl \$0-rcv-tre-tgl empty 17 7
-0 10 -1 -262144 -1 0 1;
+0 10 #000000 #fcfcfc #000000 0 1;
 #X text 484 172 ON/OFF;
 #X text 484 292 DEPTH;
-#X obj 15 40 cnv 17 84 102 empty empty empty 20 12 0 14 -228856 -66577
+#X obj 15 40 cnv 17 84 102 empty empty empty 20 12 0 14 #dcdcdc #404040
 0;
 #X obj 20 80 nbx 4 17 -100 0 0 0 \$0-snd-mas \$0-rcv-mas empty 0 -8
-0 10 -1 -262144 -1 0 256;
+0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 68 81 dB;
 #X text 18 64 MASTER LEVEL;
 #X obj 20 120 bng 17 250 50 0 \$0-snd-mid \$0-rcv-mid empty 17 7 0
-10 -1 -258113 -1;
+10 #000000 #fc0400 #000000;
 #X text 18 104 MIDI;
 #X obj 60 120 bng 17 250 50 0 \$0-snd-stp \$0-rcv-stp empty 17 7 0
-10 -1 -258113 -1;
+10 #000000 #fc0400 #000000;
 #X text 58 104 STOP;
-#X obj 35 10 cnv 24 541 24 empty empty EP-MK1 -5 3 0 24 -66577 -262144
+#X obj 35 10 cnv 24 541 24 empty empty EP-MK1 0 12 0 24 #404040 #fcfcfc
 0;
-#X obj 10 10 cnv 24 24 24 empty empty empty 20 12 0 14 -262144 -262144
+#X obj 10 10 cnv 24 24 24 empty empty empty 20 12 0 14 #fcfcfc #fcfcfc
 0;
-#X obj 15 148 cnv 23 144 23 empty empty empty 20 12 0 14 -262130 -66577
+#X obj 15 148 cnv 23 144 23 empty empty empty 20 12 0 14 #fcfcc4 #404040
 0;
 #X text 18 152 –––––––– TINE ––––––––
 ;
-#X obj 165 148 cnv 23 160 23 empty empty empty 20 12 0 14 -261234 -66577
+#X obj 165 148 cnv 23 160 23 empty empty empty 20 12 0 14 #fcc4c4 #404040
 0;
 #X text 168 152 ––––––– TONE BAR –––––––
 ;
-#X obj 331 148 cnv 23 144 23 empty empty empty 20 12 0 14 -261682 -66577
+#X obj 331 148 cnv 23 144 23 empty empty empty 20 12 0 14 #fce0c4 #404040
 0;
-#X obj 481 148 cnv 23 90 23 empty empty empty 20 12 0 14 -203904 -66577
+#X obj 481 148 cnv 23 90 23 empty empty empty 20 12 0 14 #c4c4fc #404040
 0;
 #X text 484 152 –– TREMOLO ––;
 #X text 334 152 ––––––– PICKUP –––––––
 ;
-#X obj 15 40 cnv 23 84 23 empty empty empty 20 12 0 14 -204786 -66577
+#X obj 15 40 cnv 23 84 23 empty empty empty 20 12 0 14 #c4fcc4 #404040
 0;
 #X text 18 44 –– OUTPUT ––;
 #X text 18 212 HIGH-PASS FILTER;
 #X text 334 212 LOW-PASS FILTER;
-#X obj 105 40 cnv 17 310 102 empty empty empty 20 12 0 14 -228856 -66577
+#X obj 105 40 cnv 17 310 102 empty empty empty 20 12 0 14 #dcdcdc #404040
 0;
 #X obj 110 80 nbx 5 17 100 20000 0 0 \$0-bas-frq \$0-rcv-bas-frq empty
-0 -8 0 10 -1 -262144 -1 100 256;
+0 -8 0 10 #000000 #fcfcfc #000000 100 256 0;
 #X text 108 64 BASE FREQUENCY;
 #X obj 210 80 nbx 5 17 0 127 0 0 \$0-bas-mid \$0-rcv-bas-mid empty
-0 -8 0 10 -1 -262144 -1 0 256;
+0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 208 64 BASE MIDI NOTE;
 #X obj 110 120 nbx 5 17 1 100 0 0 \$0-num-div \$0-rcv-num-div empty
-0 -8 0 10 -33289 -262144 -1 1 256;
+0 -8 0 10 #202020 #fcfcfc #000000 1 256 0;
 #X obj 210 120 nbx 5 17 0 20 0 0 \$0-int-div \$0-rcv-int-div empty
-0 -8 0 10 -1 -262144 -1 0 256;
+0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 108 104 # of DIVISIONS;
 #X text 208 104 INTERVAL TO DIVIDE;
-#X obj 105 40 cnv 23 310 23 empty empty empty 20 12 0 14 -232576 -66577
+#X obj 105 40 cnv 23 310 23 empty empty empty 20 12 0 14 #e0c4fc #404040
 0;
 #X obj 340 120 bng 17 250 50 0 \$0-loadscale empty empty 17 7 0 10
--1 -258113 -1;
+#000000 #fc0400 #000000;
 #X text 338 104 LOAD SCALE;
 #X text 168 81 Hz;
 #X obj 340 80 tgl 17 0 \$0-snd-txt-tgl \$0-rcv-txt-tgl empty 17 7 0
-10 -1 -262144 -1 0 1;
+10 #000000 #fcfcfc #000000 0 1;
 #X text 338 64 TEXT SCALE;
 #X text 358 81 ON/OFF;
 #X text 108 44 –––––––––––––––––––––
@@ -35879,9 +35879,9 @@ TUNING –––––––––––––––––––––
 #X text 323 104 |;
 #X text 323 114 |;
 #X text 323 124 |;
-#X obj 421 40 cnv 17 150 102 empty empty empty 20 12 0 14 -228856 -66577
+#X obj 421 40 cnv 17 150 102 empty empty empty 20 12 0 14 #dcdcdc #404040
 0;
-#X obj 421 40 cnv 23 150 23 empty empty empty 20 12 0 14 -262144 -66577
+#X obj 421 40 cnv 23 150 23 empty empty empty 20 12 0 14 #fcfcfc #404040
 0;
 #X text 424 44 –––––––– INFO –––––––––
 ;
@@ -35889,6 +35889,7 @@ TUNING –––––––––––––––––––––
 #X text 424 119 mianmogra94@gmail.com;
 #X text 424 69 DONATE;
 #X text 424 79 paypal.me/mianmogra;
+#X obj 584 180 ctlin 123;
 #X connect 1 0 0 0;
 #X connect 1 0 0 1;
 #X connect 2 0 3 0;
@@ -35965,4 +35966,5 @@ TUNING –––––––––––––––––––––
 #X connect 81 1 74 0;
 #X connect 81 2 59 2;
 #X connect 82 0 37 0;
+#X connect 199 0 152 0;
 #X coords 0 -1 1 1 566 325 2 10 10;

--- a/EP-MK1_Pd_Standalone/EP-MK1.pd
+++ b/EP-MK1_Pd_Standalone/EP-MK1.pd
@@ -1242,7 +1242,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 12 75 pd voice;
-#X f 10;
 #X obj 12 12 r \$0-poly;
 #X obj 12 33 route 1;
 #X obj 12 54 unpack f f;
@@ -2339,7 +2338,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 82 75 pd voice;
-#X f 10;
 #X obj 82 12 r \$0-poly;
 #X obj 82 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -3434,7 +3432,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 152 75 pd voice;
-#X f 10;
 #X obj 152 12 r \$0-poly;
 #X obj 152 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -4529,7 +4526,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 222 75 pd voice;
-#X f 10;
 #X obj 222 12 r \$0-poly;
 #X obj 222 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -5624,7 +5620,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 292 75 pd voice;
-#X f 10;
 #X obj 292 12 r \$0-poly;
 #X obj 292 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -6719,7 +6714,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 362 75 pd voice;
-#X f 10;
 #X obj 362 12 r \$0-poly;
 #X obj 362 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -7814,7 +7808,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 432 75 pd voice;
-#X f 10;
 #X obj 432 12 r \$0-poly;
 #X obj 432 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -8909,7 +8902,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 502 75 pd voice;
-#X f 10;
 #X obj 502 12 r \$0-poly;
 #X obj 502 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -10004,7 +9996,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 572 75 pd voice;
-#X f 10;
 #X obj 572 12 r \$0-poly;
 #X obj 572 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -11099,7 +11090,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 642 75 pd voice;
-#X f 10;
 #X obj 642 12 r \$0-poly;
 #X obj 642 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -12194,7 +12184,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 712 75 pd voice;
-#X f 10;
 #X obj 712 12 r \$0-poly;
 #X obj 712 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -13289,7 +13278,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 782 75 pd voice;
-#X f 10;
 #X obj 782 12 r \$0-poly;
 #X obj 782 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -14384,7 +14372,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 852 75 pd voice;
-#X f 10;
 #X obj 852 12 r \$0-poly;
 #X obj 852 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -15479,7 +15466,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 922 75 pd voice;
-#X f 10;
 #X obj 922 12 r \$0-poly;
 #X obj 922 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -16574,7 +16560,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 992 75 pd voice;
-#X f 10;
 #X obj 992 12 r \$0-poly;
 #X obj 992 54 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -17669,7 +17654,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 12 165 pd voice;
-#X f 10;
 #X obj 12 102 r \$0-poly;
 #X obj 12 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -18764,7 +18748,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 82 165 pd voice;
-#X f 10;
 #X obj 82 102 r \$0-poly;
 #X obj 82 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -19859,7 +19842,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 152 165 pd voice;
-#X f 10;
 #X obj 152 102 r \$0-poly;
 #X obj 152 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -20954,7 +20936,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 222 165 pd voice;
-#X f 10;
 #X obj 222 102 r \$0-poly;
 #X obj 222 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -22049,7 +22030,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 292 165 pd voice;
-#X f 10;
 #X obj 292 102 r \$0-poly;
 #X obj 292 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -23144,7 +23124,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 362 165 pd voice;
-#X f 10;
 #X obj 362 102 r \$0-poly;
 #X obj 362 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -24239,7 +24218,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 432 165 pd voice;
-#X f 10;
 #X obj 432 102 r \$0-poly;
 #X obj 432 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -25334,7 +25312,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 502 165 pd voice;
-#X f 10;
 #X obj 502 102 r \$0-poly;
 #X obj 502 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -26429,7 +26406,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 572 165 pd voice;
-#X f 10;
 #X obj 572 102 r \$0-poly;
 #X obj 572 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -27524,7 +27500,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 642 165 pd voice;
-#X f 10;
 #X obj 642 102 r \$0-poly;
 #X obj 642 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -28619,7 +28594,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 712 165 pd voice;
-#X f 10;
 #X obj 712 102 r \$0-poly;
 #X obj 712 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -29714,7 +29688,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 782 165 pd voice;
-#X f 10;
 #X obj 782 102 r \$0-poly;
 #X obj 782 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -30809,7 +30782,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 852 165 pd voice;
-#X f 10;
 #X obj 852 102 r \$0-poly;
 #X obj 852 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -31904,7 +31876,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 922 165 pd voice;
-#X f 10;
 #X obj 922 102 r \$0-poly;
 #X obj 922 144 unpack f f;
 #N canvas 722 50 825 999 voice 0;
@@ -32999,7 +32970,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 992 165 pd voice;
-#X f 10;
 #X obj 992 102 r \$0-poly;
 #X obj 992 144 unpack f f;
 #X obj 82 33 route 2;
@@ -34123,7 +34093,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 1062 75 pd voice;
-#X f 10;
 #X obj 1062 12 r \$0-poly;
 #X obj 1062 54 unpack f f;
 #X obj 1062 33 route 16;
@@ -35219,7 +35188,6 @@
 #X connect 120 0 124 0;
 #X connect 121 0 124 0;
 #X restore 1062 165 pd voice;
-#X f 10;
 #X obj 1062 102 r \$0-poly;
 #X obj 1062 144 unpack f f;
 #X obj 1062 123 route 32;
@@ -35416,81 +35384,81 @@
 #X msg 596 283 stop;
 #X obj 816 332 s \$0-rcv-mid;
 #X obj 596 262 r \$0-snd-stp;
-#X obj 10 35 cnv 24 566 300 empty empty empty 20 12 0 14 -162280 -66577
+#X obj 10 35 cnv 24 566 300 empty empty empty 20 12 0 14 #9c9c9c #404040
 0;
-#X obj 15 148 cnv 17 144 182 empty empty empty 20 12 0 14 -228856 -66577
+#X obj 15 148 cnv 17 144 182 empty empty empty 20 12 0 14 #dcdcdc #404040
 0;
-#X obj 581 174 ctlin 64;
-#X obj 165 148 cnv 17 160 182 empty empty empty 20 12 0 14 -228856
--66577 0;
-#X obj 331 148 cnv 17 144 182 empty empty empty 20 12 0 14 -228856
--66577 0;
-#X obj 481 148 cnv 17 90 182 empty empty empty 20 12 0 14 -228856 -66577
+#X obj 590 170 ctlin 64;
+#X obj 165 148 cnv 17 160 182 empty empty empty 20 12 0 14 #dcdcdc
+#404040 0;
+#X obj 331 148 cnv 17 144 182 empty empty empty 20 12 0 14 #dcdcdc
+#404040 0;
+#X obj 481 148 cnv 17 90 182 empty empty empty 20 12 0 14 #dcdcdc #404040
 0;
-#X obj 105 40 cnv 17 310 102 empty empty empty 20 12 0 14 -228856 -66577
+#X obj 105 40 cnv 17 310 102 empty empty empty 20 12 0 14 #dcdcdc #404040
 0;
 #X obj 110 80 nbx 5 17 100 20000 0 1 \$0-bas-frq \$0-rcv-bas-frq empty
-0 -8 0 10 -1 -262144 -1 440 256;
+0 -8 0 10 #000000 #fcfcfc #000000 440 256 0;
 #X text 108 64 BASE FREQUENCY;
 #X obj 210 80 nbx 5 17 0 127 0 1 \$0-bas-mid \$0-rcv-bas-mid empty
-0 -8 0 10 -1 -262144 -1 69 256;
+0 -8 0 10 #000000 #fcfcfc #000000 69 256 0;
 #X text 208 64 BASE MIDI NOTE;
 #X obj 110 120 nbx 5 17 1 100 0 1 \$0-num-div \$0-rcv-num-div empty
-0 -8 0 10 -33289 -262144 -1 12 256;
+0 -8 0 10 #202020 #fcfcfc #000000 12 256 0;
 #X obj 210 120 nbx 5 17 0 20 0 1 \$0-int-div \$0-rcv-int-div empty
-0 -8 0 10 -1 -262144 -1 2 256;
+0 -8 0 10 #000000 #fcfcfc #000000 2 256 0;
 #X text 108 104 # of DIVISIONS;
 #X text 208 104 INTERVAL TO DIVIDE;
 #X obj 170 228 nbx 4 17 1 2000 0 1 \$0-ton-rel \$0-rcv-ton-rel empty
-0 -8 0 10 -1 -262144 -1 10 256;
+0 -8 0 10 #000000 #fcfcfc #000000 10 256 0;
 #X text 168 212 RELEASE;
 #X obj 170 188 nbx 4 17 1 2000 0 1 \$0-ton-dec \$0-rcv-ton-dec empty
-0 -8 0 10 -1 -262144 -1 1000 256;
+0 -8 0 10 #000000 #fcfcfc #000000 1000 256 0;
 #X text 168 172 DECAY;
 #X obj 170 268 nbx 4 17 -100 0 0 1 \$0-snd-ton-lvl \$0-rcv-ton-lvl
-empty 0 -8 0 10 -1 -262144 -1 -6 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 -6 256 0;
 #X text 168 252 LEVEL;
-#X obj 240 188 tgl 17 1 \$0-snd-pdl \$0-rcv-pdl empty 17 7 0 10 -1
--262144 -1 0 1;
+#X obj 240 188 tgl 17 1 \$0-snd-pdl \$0-rcv-pdl empty 17 7 0 10 #000000
+#fcfcfc #000000 0 1;
 #X text 238 172 SUS. PEDAL;
 #X obj 336 228 nbx 5 17 20 20000 0 1 \$0-pic-lop \$0-rcv-pic-lop empty
-0 -8 0 10 -1 -262144 -1 1000 256;
+0 -8 0 10 #000000 #fcfcfc #000000 1000 256 0;
 #X obj 336 188 nbx 4 17 0 24 0 1 \$0-snd-pic-gan \$0-rcv-pic-gan empty
-0 -8 0 10 -1 -262144 -1 13 256;
+0 -8 0 10 #000000 #fcfcfc #000000 13 256 0;
 #X text 384 189 dB;
 #X text 394 229 Hz;
 #X obj 336 268 nbx 4 17 0 24 0 1 \$0-snd-pic-sym \$0-rcv-pic-sym empty
-0 -8 0 10 -1 -262144 -1 15 256;
+0 -8 0 10 #000000 #fcfcfc #000000 15 256 0;
 #X text 334 252 SYMMETRY;
 #X text 384 269 dB;
 #X obj 336 308 nbx 4 17 -100 6 0 1 \$0-snd-pic-lvl \$0-rcv-pic-lvl
-empty 0 -8 0 10 -1 -262144 -1 -12 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 -12 256 0;
 #X text 334 292 LEVEL;
 #X obj 240 268 nbx 4 17 -100 0 0 1 \$0-snd-ham-lvl \$0-rcv-ham-lvl
-empty 0 -8 0 10 -1 -262144 -1 -24 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 -24 256 0;
 #X text 288 269 dB;
 #X text 218 269 dB;
 #X text 238 252 HAMMER LEVEL;
 #X obj 240 228 nbx 4 17 -100 0 0 1 \$0-snd-off-lvl \$0-rcv-off-lvl
-empty 0 -8 0 10 -1 -262144 -1 -30 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 -30 256 0;
 #X text 288 229 dB;
 #X text 238 212 NOTEOFF LEVEL;
 #X obj 20 228 nbx 5 17 20 20000 0 1 \$0-tin-hip \$0-rcv-tin-hip empty
-0 -8 0 10 -1 -262144 -1 1500 256;
+0 -8 0 10 #000000 #fcfcfc #000000 1500 256 0;
 #X text 78 229 Hz;
 #X obj 20 188 nbx 4 17 0 30 0 1 \$0-tin-rat-1 \$0-rcv-tin-rat-1 empty
-0 -8 0 10 -1 -262144 -1 7 256;
+0 -8 0 10 #000000 #fcfcfc #000000 7 256 0;
 #X obj 80 188 nbx 4 17 0 30 0 1 \$0-tin-rat-2 \$0-rcv-tin-rat-2 empty
-0 -8 0 10 -1 -262144 -1 20 256;
+0 -8 0 10 #000000 #fcfcfc #000000 20 256 0;
 #X obj 20 268 nbx 4 17 1 2000 0 1 \$0-tin-dec \$0-rcv-tin-dec empty
-0 -8 0 10 -1 -262144 -1 500 256;
+0 -8 0 10 #000000 #fcfcfc #000000 500 256 0;
 #X text 384 309 dB;
 #X obj 20 308 nbx 4 17 -100 0 0 1 \$0-snd-tin-lvl \$0-rcv-tin-lvl empty
-0 -8 0 10 -1 -262144 -1 -16 256;
+0 -8 0 10 #000000 #fcfcfc #000000 -16 256 0;
 #X text 18 292 LEVEL;
 #X text 68 309 dB;
 #X obj 406 188 nbx 4 17 -100 30 0 1 \$0-snd-pic-atk \$0-rcv-pic-atk
-empty 0 -8 0 10 -1 -262144 -1 3 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 3 256 0;
 #X text 454 189 dB;
 #X text 404 172 ATTACK;
 #X text 334 172 GAIN;
@@ -35498,45 +35466,45 @@ empty 0 -8 0 10 -1 -262144 -1 3 256;
 #X text 18 172 RATIO 1;
 #X text 78 172 RATIO 2;
 #X obj 406 308 nbx 4 17 -100 0 0 1 \$0-snd-pic-buz \$0-rcv-pic-buz
-empty 0 -8 0 10 -1 -262144 -1 -6 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 -6 256 0;
 #X text 454 309 dB;
 #X text 404 292 BUZZ LEVEL;
 #X obj 406 268 tgl 17 1 \$0-snd-buz-pha \$0-rcv-buz-pha empty 17 7
-0 10 -1 -262144 -1 1 1;
+0 10 #000000 #fcfcfc #000000 1 1;
 #X text 404 252 BUZZ PHASE;
 #X obj 90 308 nbx 4 17 -100 24 0 1 \$0-snd-tin-snd \$0-rcv-tin-snd
-empty 0 -8 0 10 -1 -262144 -1 -12 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 -12 256 0;
 #X text 138 309 dB;
 #X text 88 292 PICK SEND;
 #X obj 486 268 nbx 5 17 0 20000 0 1 \$0-tre-rat \$0-rcv-tre-rat empty
-0 -8 0 10 -1 -262144 -1 3 256;
+0 -8 0 10 #000000 #fcfcfc #000000 3 256 0;
 #X text 544 269 Hz;
 #X text 484 252 RATE;
 #X obj 486 228 nbx 4 17 0 127 0 1 \$0-tre-sha \$0-rcv-tre-sha empty
-0 -8 0 10 -1 -262144 -1 0 256;
+0 -8 0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 484 212 SHAPE SIN/TRI;
 #X obj 486 308 nbx 4 17 -100 0 0 1 \$0-snd-tre-dep \$0-rcv-tre-dep
-empty 0 -8 0 10 -1 -262144 -1 -9 256;
+empty 0 -8 0 10 #000000 #fcfcfc #000000 -9 256 0;
 #X text 534 309 dB;
 #X obj 486 188 tgl 17 1 \$0-snd-tre-tgl \$0-rcv-tre-tgl empty 17 7
-0 10 -1 -262144 -1 1 1;
+0 10 #000000 #fcfcfc #000000 1 1;
 #X text 484 172 ON/OFF;
 #X text 484 292 DEPTH;
-#X obj 15 40 cnv 17 84 102 empty empty empty 20 12 0 14 -228856 -66577
+#X obj 15 40 cnv 17 84 102 empty empty empty 20 12 0 14 #dcdcdc #404040
 0;
 #X obj 20 80 nbx 4 17 -100 0 0 1 \$0-snd-mas \$0-rcv-mas empty 0 -8
-0 10 -1 -262144 -1 0 256;
+0 10 #000000 #fcfcfc #000000 0 256 0;
 #X text 68 81 dB;
 #X text 18 64 MASTER LEVEL;
 #X obj 20 120 bng 17 250 50 0 \$0-snd-mid \$0-rcv-mid empty 17 7 0
-10 -1 -258113 -1;
+10 #000000 #fc0400 #000000;
 #X text 18 104 MIDI;
 #X obj 60 120 bng 17 250 50 0 \$0-snd-stp \$0-rcv-stp empty 17 7 0
-10 -1 -258113 -1;
+10 #000000 #fc0400 #000000;
 #X text 58 104 STOP;
-#X obj 35 10 cnv 24 540 24 empty empty EP-MK1 5 14 0 24 -66577 -262144
+#X obj 35 10 cnv 24 540 24 empty empty EP-MK1 5 14 0 24 #404040 #fcfcfc
 0;
-#X obj 10 10 cnv 24 24 24 empty empty empty 20 12 0 14 -262144 -262144
+#X obj 10 10 cnv 24 24 24 empty empty empty 20 12 0 14 #fcfcfc #fcfcfc
 0;
 #X obj 418 504 r \$0-snd-mas;
 #X obj 418 525 + 100;
@@ -35545,37 +35513,37 @@ empty 0 -8 0 10 -1 -262144 -1 -9 256;
 #X obj 418 588 line~;
 #X obj 21 602 *~;
 #X obj 21 555 /~ 2;
-#X obj 15 148 cnv 23 144 23 empty empty empty 20 12 0 14 -262130 -66577
+#X obj 15 148 cnv 23 144 23 empty empty empty 20 12 0 14 #fcfcc4 #404040
 0;
 #X text 18 152 –––––––– TINE ––––––––
 ;
-#X obj 165 148 cnv 23 160 23 empty empty empty 20 12 0 14 -261234 -66577
+#X obj 165 148 cnv 23 160 23 empty empty empty 20 12 0 14 #fcc4c4 #404040
 0;
 #X text 168 152 ––––––– TONE BAR –––––––
 ;
-#X obj 331 148 cnv 23 144 23 empty empty empty 20 12 0 14 -261682 -66577
+#X obj 331 148 cnv 23 144 23 empty empty empty 20 12 0 14 #fce0c4 #404040
 0;
-#X obj 481 148 cnv 23 90 23 empty empty empty 20 12 0 14 -203904 -66577
+#X obj 481 148 cnv 23 90 23 empty empty empty 20 12 0 14 #c4c4fc #404040
 0;
 #X text 484 152 –– TREMOLO ––;
 #X text 334 152 ––––––– PICKUP –––––––
 ;
-#X obj 105 40 cnv 23 310 23 empty empty empty 20 12 0 14 -232576 -66577
+#X obj 105 40 cnv 23 310 23 empty empty empty 20 12 0 14 #e0c4fc #404040
 0;
-#X obj 15 40 cnv 23 84 23 empty empty empty 20 12 0 14 -204786 -66577
+#X obj 15 40 cnv 23 84 23 empty empty empty 20 12 0 14 #c4fcc4 #404040
 0;
 #X text 18 44 –– OUTPUT ––;
-#X text 584 74 GitHub: github.com/MikeMorenoAudio;
-#X text 584 89 Facebook: fb.com/MikeMorenoAudio;
-#X text 584 119 WordPress: mikemorenoaudio.wordpress.com;
-#X text 584 134 PatchStorage: patchstorage.com/author/mianmogra;
-#X text 584 104 Youtube: youtube.com/c/MikeMorenoAudio;
-#X text 584 24 DONATE;
-#X text 584 39 paypal.me/mianmogra;
+#X text 660 75 GitHub: github.com/MikeMorenoAudio;
+#X text 660 90 Facebook: fb.com/MikeMorenoAudio;
+#X text 660 120 WordPress: mikemorenoaudio.wordpress.com;
+#X text 660 135 PatchStorage: patchstorage.com/author/mianmogra;
+#X text 660 105 Youtube: youtube.com/c/MikeMorenoAudio;
+#X text 660 25 DONATE;
+#X text 660 40 paypal.me/mianmogra;
 #X text 18 212 HIGH-PASS FILTER;
 #X text 334 212 LOW-PASS FILTER;
 #X obj 340 120 bng 17 250 50 0 \$0-loadscale empty empty 17 7 0 10
--1 -258113 -1;
+#000000 #fc0400 #000000;
 #X text 338 104 LOAD SCALE;
 #X obj 525 493 list trim;
 #X obj 525 472 list prepend read;
@@ -35605,7 +35573,7 @@ empty 0 -8 0 10 -1 -262144 -1 -9 256;
 #X msg 498 535 \; pd-EP-MK1.pd menusave;
 #X text 168 81 Hz;
 #X obj 340 80 tgl 17 1 \$0-snd-txt-tgl \$0-rcv-txt-tgl empty 17 7 0
-10 -1 -262144 -1 0 1;
+10 #000000 #fcfcfc #000000 0 1;
 #X text 338 64 TEXT SCALE;
 #X text 358 81 ON/OFF;
 #X text 108 44 –––––––––––––––––––––
@@ -35629,9 +35597,9 @@ TUNING –––––––––––––––––––––
 #X obj 698 375 list prepend;
 #X obj 784 361 r \$0-int-div;
 #X obj 498 430 t b b;
-#X obj 421 40 cnv 17 150 102 empty empty empty 20 12 0 14 -228856 -66577
+#X obj 421 40 cnv 17 150 102 empty empty empty 20 12 0 14 #dcdcdc #404040
 0;
-#X obj 421 40 cnv 23 150 23 empty empty empty 20 12 0 14 -262144 -66577
+#X obj 421 40 cnv 23 150 23 empty empty empty 20 12 0 14 #fcfcfc #404040
 0;
 #X msg 498 567 1;
 #X obj 498 588 s \$0-rcv-txt-tgl;
@@ -35646,8 +35614,9 @@ TUNING –––––––––––––––––––––
 #X text 424 69 DONATE;
 #X text 424 79 paypal.me/mianmogra;
 #X obj 676 297 poly 32 1;
-#X text 665 184 https://sevish.com/scaleworkshop/;
-#X text 655 164 Use a Scale Workshop for creating scales;
+#X text 670 180 https://sevish.com/scaleworkshop/;
+#X text 660 160 Use a Scale Workshop for creating scales;
+#X obj 590 100 ctlin 123;
 #X connect 1 0 2 0;
 #X connect 3 0 199 0;
 #X connect 3 1 40 0;
@@ -35729,4 +35698,5 @@ TUNING –––––––––––––––––––––
 #X connect 199 1 175 0;
 #X connect 199 1 182 0;
 #X connect 199 2 1 2;
+#X connect 202 0 124 0;
 #X coords 0 -1 1 1 566 325 2 10 10;


### PR DESCRIPTION
Added a `ctlin 123` object to the Linux plugin and the standalone, that triggers the stop button. I have not recompiled the files, nor made the same change to the other distributions for the plugin.

Side note: Camomile no longer supports VST2, so maybe switching to VST3 will be a good idea. I've found that the VST2 versions crash when opened alongside VST3 plugins in a plugin host, but the same issue does not happen when you compile for VST3 instead.